### PR TITLE
Add support for flatpak-installed Firefox

### DIFF
--- a/rookie-rs/src/config.rs
+++ b/rookie-rs/src/config.rs
@@ -269,7 +269,8 @@ cfg_if::cfg_if! {
         pub static FIREFOX_CONFIG: BrowserConfig<'static> = BrowserConfig {
             data_paths: &[
                 "~/snap/firefox/common/.mozilla/firefox",
-                "~/.mozilla/firefox"
+                "~/.mozilla/firefox",
+                "~/.var/app/org.mozilla.firefox/.mozilla/firefox"
             ],
             channels: None,
             os_crypt_name: None,


### PR DESCRIPTION
Tested on Fedora and Ubuntu, Flatpak Firefox uses this path.