### PR TITLE
Improve typing in python binding

### DIFF
--- a/bindings/python/rookiepy/__init__.py
+++ b/bindings/python/rookiepy/__init__.py
@@ -1,5 +1,5 @@
 from sys import platform
-from typing import List
+from typing import Any, Dict, List, Optional
 import http.cookiejar
 from .rookiepy import (
     firefox,
@@ -29,12 +29,15 @@ __all__ = [
     "vivaldi",
     "chromium_based",
     "firefox_based",
-    "to_dict",
+    "to_dict", # type: ignore
     "to_cookiejar",
     "create_cookie",
     "load",
     "any_browser"
 ]
+
+
+CookieList = List[Dict[str, Any]]
 
 
 # Windows
@@ -53,25 +56,48 @@ if platform == "darwin":
     ])
 
 
-def create_cookie(host, path, secure, expires, name, value, http_only):
+def create_cookie(
+        host: str,
+        path: str,
+        secure: bool,
+        expires: Optional[int],
+        name: str,
+        value: Optional[str],
+        http_only: bool,
+        ) -> http.cookiejar.Cookie:
     """
     Create a Cookie object with the specified attributes.
 
-    :param host: The domain for which the cookie is valid
-    :param path: The path within the domain for which the cookie is valid
-    :param secure: True if the cookie should only be sent over secure connections (HTTPS)
-    :param expires: Unix timestamp indicating when the cookie expires
-    :param name: The name of the cookie
-    :param value: The value of the cookie
-    :param http_only: True if the cookie should only be accessible via HTTP and not JavaScript
+    :param str host: The domain for which the cookie is valid
+    :param str path: The path within the domain for which the cookie is valid
+    :param bool secure: True if the cookie should only be sent over secure connections (HTTPS)
+    :param Optional[int] expires: Unix timestamp indicating when the cookie expires
+    :param str name: The name of the cookie
+    :param Optional[str] value: The value of the cookie
+    :param bool http_only: True if the cookie should only be accessible via HTTP and not JavaScript
     :return: A Cookie object
+    :rtype: http.cookiejar.Cookie
     """
     # HTTPOnly flag goes in _rest, if present (see https://github.com/python/cpython/pull/17471/files#r511187060)
-    return http.cookiejar.Cookie(0, name, value, None, False, host, host.startswith('.'), host.startswith('.'), path,
-                                 True, secure, expires, False, None, None,
-                                 {'HTTPOnly': ''} if http_only else {})
+    return http.cookiejar.Cookie(version=0,
+                                 name=name,
+                                 value=value,
+                                 port=None,
+                                 port_specified=False,
+                                 domain=host,
+                                 domain_specified=host.startswith('.'),
+                                 domain_initial_dot=host.startswith('.'),
+                                 path=path,
+                                 path_specified=True,
+                                 secure=secure,
+                                 expires=expires,
+                                 discard=False,
+                                 comment=None,
+                                 comment_url=None,
+                                 rest={'HTTPOnly': ''} if http_only else {}
+                                 )
 
-def to_cookiejar(cookies: List[dict]):
+def to_cookiejar(cookies: CookieList) -> http.cookiejar.CookieJar:
     """
     Convert a list of dictionaries representing cookies to a CookieJar.
 

--- a/bindings/python/rookiepy/rookiepy.pyi
+++ b/bindings/python/rookiepy/rookiepy.pyi
@@ -1,8 +1,9 @@
-from typing import List
+from typing import Any, Dict, List, Optional
 from sys import platform
 
+CookieList = List[Dict[str, Any]]
 
-def firefox(domains: List[str] = None) -> List[dict]:
+def firefox(domains: Optional[List[str]] = None) -> CookieList:
     """
     Extract Cookies from Firefox
 
@@ -12,7 +13,7 @@ def firefox(domains: List[str] = None) -> List[dict]:
     ...
 
 
-def firefox_based(key_path: str, db_path: str, domains: List[str] = None) -> List[dict]:
+def firefox_based(key_path: str, db_path: str, domains: Optional[List[str]] = None) -> CookieList:
     """
     Extract Cookies from Firefox-based browsers
 
@@ -24,7 +25,7 @@ def firefox_based(key_path: str, db_path: str, domains: List[str] = None) -> Lis
     ...
 
 
-def brave(domains: List[str] = None) -> List[dict]:
+def brave(domains: Optional[List[str]] = None) -> CookieList:
     """
     Extract Cookies from Brave browser
 
@@ -34,7 +35,7 @@ def brave(domains: List[str] = None) -> List[dict]:
     ...
 
 
-def edge(domains: List[str] = None) -> List[dict]:
+def edge(domains: Optional[List[str]] = None) -> CookieList:
     """
     Extract Cookies from Microsoft Edge browser
 
@@ -44,7 +45,7 @@ def edge(domains: List[str] = None) -> List[dict]:
     ...
 
 
-def chrome(domains: List[str] = None) -> List[dict]:
+def chrome(domains: Optional[List[str]] = None) -> CookieList:
     """
     Extract Cookies from Google Chrome browser
 
@@ -54,7 +55,7 @@ def chrome(domains: List[str] = None) -> List[dict]:
     ...
 
 
-def chromium_based(db_path: str, domains: List[str] = None) -> List[dict]:
+def chromium_based(db_path: str, domains: Optional[List[str]] = None) -> CookieList:
     """
     Extract Cookies from Chromium-based browsers
 
@@ -65,7 +66,7 @@ def chromium_based(db_path: str, domains: List[str] = None) -> List[dict]:
     ...
 
 
-def chromium(domains: List[str] = None) -> List[dict]:
+def chromium(domains: Optional[List[str]] = None) -> CookieList:
     """
     Extract Cookies from Chromium browser
 
@@ -75,7 +76,7 @@ def chromium(domains: List[str] = None) -> List[dict]:
     ...
 
 
-def opera(domains: List[str] = None) -> List[dict]:
+def opera(domains: Optional[List[str]] = None) -> CookieList:
     """
     Extract Cookies from Opera browser
 
@@ -85,7 +86,7 @@ def opera(domains: List[str] = None) -> List[dict]:
     ...
 
 
-def vivaldi(domains: List[str] = None) -> List[dict]:
+def vivaldi(domains: Optional[List[str]] = None) -> CookieList:
     """
     Extract Cookies from Vivaldi browser
 
@@ -95,7 +96,7 @@ def vivaldi(domains: List[str] = None) -> List[dict]:
     ...
 
 
-def opera_gx(domains: List[str] = None) -> List[dict]:
+def opera_gx(domains: Optional[List[str]] = None) -> CookieList:
     """
     Extract Cookies from Opera GX browser
 
@@ -105,7 +106,7 @@ def opera_gx(domains: List[str] = None) -> List[dict]:
     ...
 
 
-def libre_wolf(domains: List[str] = None) -> List[dict]:
+def libre_wolf(domains: Optional[List[str]] = None) -> CookieList:
     """
     Extract Cookies from LibreWolf browser
 
@@ -115,7 +116,7 @@ def libre_wolf(domains: List[str] = None) -> List[dict]:
     ...
 
 
-def load(domains: List[str] = None) -> List[dict]:
+def load(domains: Optional[List[str]] = None) -> CookieList:
     """
     Load Cookies from a browser
 
@@ -125,7 +126,7 @@ def load(domains: List[str] = None) -> List[dict]:
     ...
 
 
-def any_browser(domains: List[str] = None) -> List[dict]:
+def any_browser(domains: Optional[List[str]] = None) -> CookieList:
     """
     Extract Cookies from any browser
 
@@ -137,7 +138,7 @@ def any_browser(domains: List[str] = None) -> List[dict]:
 
 # Windows
 if platform == "win32":
-    def internet_explorer(domains: List[str] = None) -> List[dict]:
+    def internet_explorer(domains: Optional[List[str]] = None) -> CookieList:
         """
         Extract Cookies from Internet Explorer
 
@@ -146,7 +147,7 @@ if platform == "win32":
         """
         ...
 
-    def octo_browser(domains: List[str] = None) -> List[dict]:
+    def octo_browser(domains: Optional[List[str]] = None) -> CookieList:
         """
         Extract Cookies from Octo browser
 
@@ -158,7 +159,7 @@ if platform == "win32":
 
 # MacOS
 if platform == "darwin":
-    def safari(domains: List[str] = None) -> List[dict]:
+    def safari(domains: Optional[List[str]] = None) -> CookieList:
         """
         Extract Cookies from Safari browser
 


### PR DESCRIPTION
Currently stict python type checker is unhappy with python typing, and some optional arguments are mistyped as mandatory in `rookiepy.pyi`. This PR would improve typing of this library.