### PR TITLE
Replace `libre_wolf` with `librewolf` and cleanup typography

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,17 +62,17 @@ See [cli](https://github.com/thewh1teagle/rookie/tree/main/cli) folder
 
 So far the following platforms are supported:
 
-- **Chrome:** `Linux`, `MacOS`, `Windows`
-- **Firefox:** `Linux`, `MacOS`, `Windows`
-- **LibreWolf:** `Linux`, `MacOS`, `Windows`
-- **Opera:** `Linux`, `MacOS`, `Windows`
-- **Opera GX:** `MacOS`, `Windows`
-- **Edge:** Linux, `MacOS`, `Windows`
+- **Chrome:** `Linux`, `macOS`, `Windows`
+- **Firefox:** `Linux`, `macOS`, `Windows`
+- **LibreWolf:** `Linux`, `macOS`, `Windows`
+- **Opera:** `Linux`, `macOS`, `Windows`
+- **Opera GX:** `macOS`, `Windows`
+- **Edge:** Linux, `macOS`, `Windows`
 - **Internet Explorer:** `Windows`
-- **Chromium:** `Linux`, `MacOS`, `Windows`
-- **Brave:** `Linux`, `MacOS`, `Windows`
-- **Vivaldi:** `Linux`, `MacOS`, `Windows`
-- **Safari:** `MacOS`
+- **Chromium:** `Linux`, `macOS`, `Windows`
+- **Brave:** `Linux`, `macOS`, `Windows`
+- **Vivaldi:** `Linux`, `macOS`, `Windows`
+- **Safari:** `macOS`
 
 You are welcome to contribute support for other browsers, or other platforms.
 
@@ -84,8 +84,8 @@ look at [config.rs](https://github.com/thewh1teagle/rookie/blob/main/rookie-rs/s
 
 ## Testing Dates  (dd/mm/yy) 📅
 
-Browser  |  Linux    |  MacOS   | Windows  |
-:------  | :------:  | :------: | :------: |
+Browser  |  Linux    |  macOS   | Windows  |
+:------  | :------:  |:--------:| :------: |
 Chrome   | 01/10/23  | 25/11/23 |  1/10/23 |
 Firefox  | 01/10/23  | 25/11/23 |  1/10/23 |
 LibreWolf| 01/10/23  | 25/11/23 |  1/10/23 |

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ So far the following platforms are supported:
 - **LibreWolf:** `Linux`, `macOS`, `Windows`
 - **Opera:** `Linux`, `macOS`, `Windows`
 - **Opera GX:** `macOS`, `Windows`
-- **Edge:** Linux, `macOS`, `Windows`
+- **Edge:** `Linux`, `macOS`, `Windows`
 - **Internet Explorer:** `Windows`
 - **Chromium:** `Linux`, `macOS`, `Windows`
 - **Brave:** `Linux`, `macOS`, `Windows`
@@ -82,21 +82,21 @@ If you have a browser with which the library isn't working with, it may not have
 
 look at [config.rs](https://github.com/thewh1teagle/rookie/blob/main/rookie-rs/src/config.rs) to see what configurations is needed.
 
-## Testing Dates  (dd/mm/yy) 📅
+## Testing Dates  (DD/MM/YY) 📅
 
-Browser  |  Linux    |  macOS   | Windows  |
-:------  | :------:  |:--------:| :------: |
-Chrome   | 01/10/23  | 25/11/23 |  1/10/23 |
-Firefox  | 01/10/23  | 25/11/23 |  1/10/23 |
-LibreWolf| 01/10/23  | 25/11/23 |  1/10/23 |
-Opera    | 01/10/23  |    -     |  1/10/23 |
-Opera GX |   N/A     |    -     |  1/10/23 |
-Edge     | 01/10/23  |    -     |  1/10/23 |
-IE       |   N/A     |   N/A    |  1/10/23 |
-Chromium | 01/10/23  | 25/11/23 |  1/10/23 |
-Brave    | 01/10/23  | 25/11/23 |  1/10/23 |
-Vivaldi  | 01/10/23  | 25/11/23 |  1/10/23 |
-Safari   |   N/A     | 02/10/23 |    N/A   |
+| Browser   |  Linux   |  macOS   | Windows  |
+|:----------|:--------:|:--------:|:--------:|
+| Chrome    | 01/10/23 | 25/11/23 | 16/03/24 |
+| Firefox   | 01/10/23 | 25/11/23 | 16/03/24 |
+| LibreWolf | 01/10/23 | 25/11/23 | 01/10/23 |
+| Opera     | 01/10/23 |    -     | 01/10/23 |
+| Opera GX  |   N/A    |    -     | 01/10/23 |
+| Edge      | 01/10/23 |    -     | 01/10/23 |
+| IE        |   N/A    |   N/A    | 01/10/23 |
+| Chromium  | 01/10/23 | 25/11/23 | 01/10/23 |
+| Brave     | 01/10/23 | 25/11/23 | 01/10/23 |
+| Vivaldi   | 01/10/23 | 25/11/23 | 01/10/23 |
+| Safari    |   N/A    | 02/10/23 |   N/A    |
 
 ## Credits 🙌
 [github.com/borisbabic/browser_cookie3](https://github.com/borisbabic/browser_cookie3)

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -10,6 +10,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 cfg-if = "1.0.0"
-pyo3 = "0.19.0"
+pyo3 = "0.20.3"
 pyo3-log = "0.9.0"
 rookie = { path = "../../rookie-rs" }

--- a/bindings/python/rookiepy/__init__.py
+++ b/bindings/python/rookiepy/__init__.py
@@ -12,14 +12,14 @@ from .rookiepy import (
     opera, 
     vivaldi,
     opera_gx,
-    libre_wolf,
+    librewolf,
     load,
     any_browser
 )
 
 __all__ = [
     "firefox",
-    "libre_wolf",
+    "librewolf",
     "brave",
     "edge",
     "chrome",

--- a/bindings/python/rookiepy/__init__.py
+++ b/bindings/python/rookiepy/__init__.py
@@ -48,7 +48,7 @@ if platform == "win32":
         "octo_browser"
     ])
 
-# MacOS
+# macOS
 if platform == "darwin":
     from .rookiepy import safari
     __all__.extend([

--- a/bindings/python/rookiepy/rookiepy.pyi
+++ b/bindings/python/rookiepy/rookiepy.pyi
@@ -106,7 +106,7 @@ def opera_gx(domains: Optional[List[str]] = None) -> CookieList:
     ...
 
 
-def libre_wolf(domains: Optional[List[str]] = None) -> CookieList:
+def librewolf(domains: Optional[List[str]] = None) -> CookieList:
     """
     Extract Cookies from LibreWolf browser
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -36,8 +36,8 @@ fn firefox(py: Python, domains: Option<Vec<&str>>) -> PyResult<Vec<PyObject>> {
 }
 
 #[pyfunction]
-fn libre_wolf(py: Python, domains: Option<Vec<&str>>) -> PyResult<Vec<PyObject>> {
-    let cookies = rookie::libre_wolf(domains).unwrap();
+fn librewolf(py: Python, domains: Option<Vec<&str>>) -> PyResult<Vec<PyObject>> {
+    let cookies = rookie::librewolf(domains).unwrap();
     let cookies = to_dict(py, cookies)?;
 
     Ok(cookies)
@@ -191,7 +191,7 @@ fn any_browser(py: Python, db_path: &str, domains: Option<Vec<&str>>, key_path: 
 fn rookiepy(_py: Python, m: &PyModule) -> PyResult<()> {
     pyo3_log::init();
     m.add_function(wrap_pyfunction!(firefox, m)?)?;
-    m.add_function(wrap_pyfunction!(libre_wolf, m)?)?;
+    m.add_function(wrap_pyfunction!(librewolf, m)?)?;
     m.add_function(wrap_pyfunction!(chrome, m)?)?;
     m.add_function(wrap_pyfunction!(brave, m)?)?;
     m.add_function(wrap_pyfunction!(edge, m)?)?;

--- a/docs/General.md
+++ b/docs/General.md
@@ -2,7 +2,7 @@
 
 ## Password prompt
 
-This library may trigger a password prompt with kde-wallet on linux / MacOS with chromium based browsers when accessing browser cookies. 
+This library may trigger a password prompt with kde-wallet on linux / macOS with chromium based browsers when accessing browser cookies. 
 
 ## Session Cookies Retrieval
 

--- a/docs/Python.md
+++ b/docs/Python.md
@@ -10,19 +10,19 @@ pip3 install -U rookiepy
 
 ```python
 import rookiepy
-cookies = rookiepy.chrome() # Load cookies from chrome
+cookies = rookiepy.chrome() # Load cookies from Chrome
 ```
 
 ## Logging
 
-Logging level can be controlled by using `logging` module
+Logging level can be controlled by using the `logging` module
 
 ```python
 import logging
 logging.getLogger('rookie').setLevel(logging.DEBUG)
 ```
 
-For disable `rookiepy` logging you can set the level to `CRITICAL`
+To fully disable `rookiepy` logging you can set the level to `CRITICAL`
 
 ```python
 import logging

--- a/docs/Rust.md
+++ b/docs/Rust.md
@@ -19,7 +19,7 @@ fn main() {
 
 ## Logging
 
-Logging level can be controlled by chaing `RUST_LOG` ENV variable
+Logging level can be controlled by changing `RUST_LOG` ENV variable
 
 ```console
 RUST_LOG=trace cargo run

--- a/rookie-rs/Cargo.toml
+++ b/rookie-rs/Cargo.toml
@@ -31,7 +31,7 @@ rust-ini = "0.21.0"
 url = "2.4.1"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
-zvariant = "4.0.2"
+zvariant = "3.15.2"
 lz4_flex = "0.11.1"
 log = "0.4.20"
 anyhow = "1.0.75"
@@ -42,7 +42,7 @@ sha1 = "0.10.6"
 pbkdf2 = "0.12.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-zbus = "4.1.2"
+zbus = "3.15.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 sha1 = "0.10.6"

--- a/rookie-rs/Cargo.toml
+++ b/rookie-rs/Cargo.toml
@@ -26,12 +26,12 @@ cbc = "0.1.2"
 cfg-if = "1.0.0"
 glob = "0.3.1"
 regex = "1.9.6"
-rusqlite = { version = "0.29.0", features = ["bundled"] }
-rust-ini = "0.19.0"
+rusqlite = { version = "0.31.0", features = ["bundled"] }
+rust-ini = "0.21.0"
 url = "2.4.1"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
-zvariant = "3.15.0"
+zvariant = "4.0.2"
 lz4_flex = "0.11.1"
 log = "0.4.20"
 anyhow = "1.0.75"
@@ -42,7 +42,7 @@ sha1 = "0.10.6"
 pbkdf2 = "0.12.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-zbus = "3.14.1"
+zbus = "4.1.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 sha1 = "0.10.6"
@@ -50,5 +50,5 @@ pbkdf2 = "0.12.2"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.51.1", features = ["Win32_Security_Cryptography", "Win32_Foundation", "Win32_System", "Win32_System_RestartManager"] }
-base64 = "0.21.4"
+base64 = "0.22.0"
 libesedb = "0.2.4"

--- a/rookie-rs/examples/http/src/main.rs
+++ b/rookie-rs/examples/http/src/main.rs
@@ -27,8 +27,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let content = response.text()?;
     let username = extract_username(content.as_str());
     match username {
-        "" => println!("Not logged in to Github"),
-        _ => println!("Logged in to Github as {username}")
+        "" => println!("Not logged in to GitHub"),
+        _ => println!("Logged in to GitHub as {username}")
     };
     Ok(())
 }

--- a/rookie-rs/src/browser/chromium.rs
+++ b/rookie-rs/src/browser/chromium.rs
@@ -108,8 +108,8 @@ fn decrypt_encrypted_value(value: String, encrypted_value: &[u8], keys: Vec<Vec<
         let key = Key::<Aes256Gcm>::from_slice(key.as_slice());
         let cipher = Aes256Gcm::new(&key);
         let nonce = GenericArray::from_slice(nonce); // 96-bits; unique per message
-        let plaintext = cipher.decrypt(nonce, ciphertext.as_ref()).or(Err(anyhow!("cant decrypt using key")))?;
-        let plaintext = String::from_utf8(plaintext).or(Err(anyhow!("cant decode encrypted value")))?;
+        let plaintext = cipher.decrypt(nonce, ciphertext.as_ref()).or(Err(anyhow!("Can't decrypt using key")))?;
+        let plaintext = String::from_utf8(plaintext).or(Err(anyhow!("Can't decode encrypted value")))?;
         return Ok(plaintext);
     }
     bail!("decrypt_encrypted_value failed")
@@ -169,14 +169,14 @@ fn decrypt_encrypted_value(value: String, encrypted_value: &[u8], keys: Vec<Vec<
 fn query_cookies(keys: Vec<Vec<u8>>, db_path: PathBuf, domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {    
     cfg_if::cfg_if! {
         if #[cfg(target_os = "windows")] {
-            let db_path_str = db_path.to_str().ok_or(anyhow!("Cant convert db path to str"))?;
-            warn!("Unlocking chrome database, it may take a while (sometimes up to minute)");
+            let db_path_str = db_path.to_str().ok_or(anyhow!("Can't convert db path to str"))?;
+            warn!("Unlocking Chrome database, it may take a while (sometimes up to minute)");
             unsafe {winapi::release_file_lock(db_path_str);}
         }
     }
 
     
-    info!("Creating sqlite connection to {}", db_path.to_str().unwrap_or(""));
+    info!("Creating SQLite connection to {}", db_path.to_str().unwrap_or(""));
     let connection = sqlite::connect(db_path)?;
     let mut query = "SELECT host_key, path, is_secure, expires_utc, name, value, encrypted_value, is_httponly, samesite FROM cookies ".to_string();
 
@@ -234,16 +234,16 @@ fn query_cookies(keys: Vec<Vec<u8>>, db_path: PathBuf, domains: Option<Vec<&str>
 pub fn chromium_based(key: PathBuf, db_path: PathBuf, domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {
     // Use DPAPI
     let content = std::fs::read_to_string(&key)?;
-    let key_dict: serde_json::Value = serde_json::from_str(content.as_str()).or(Err(anyhow!("Cant read json file")))?;
+    let key_dict: serde_json::Value = serde_json::from_str(content.as_str()).or(Err(anyhow!("Can't read json file")))?;
 
     let os_crypt = key_dict
         .get("os_crypt")
-        .ok_or(anyhow!("can't get os crypt"))?;
+        .ok_or(anyhow!("Can't get os crypt"))?;
 
     let key64 = os_crypt.get("encrypted_key")
-        .ok_or(anyhow!("cant get encrypted_key"))?
+        .ok_or(anyhow!("Can't get encrypted_key"))?
         .as_str()
-        .ok_or(anyhow!("Cant convert encrypted_key to str"))?;
+        .ok_or(anyhow!("Can't convert encrypted_key to str"))?;
 
     let keys = get_keys(key64)?;
     query_cookies(keys, db_path, domains)

--- a/rookie-rs/src/browser/mozilla.rs
+++ b/rookie-rs/src/browser/mozilla.rs
@@ -229,5 +229,5 @@ pub fn get_default_profile(profiles_path: &Path) -> Result<String> {
             }
         }
     }
-    bail!("Cant find any profile")
+    bail!("Can't find any profile")
 }

--- a/rookie-rs/src/browser/safari.rs
+++ b/rookie-rs/src/browser/safari.rs
@@ -90,7 +90,7 @@ pub fn parse_content(bs: &[u8]) -> Result<Vec<Cookie>> {
             Ok(slice) => slice,
             Err(_) => {
                 // Handle the error here, e.g., by returning the error.
-                bail!("cant get slice from page");
+                bail!("Can't get slice from page");
             }
         };
     

--- a/rookie-rs/src/common/paths.rs
+++ b/rookie-rs/src/common/paths.rs
@@ -106,7 +106,7 @@ pub fn find_mozilla_based_paths(browser_config: &BrowserConfig) -> Result<PathBu
     }
     
 
-    bail!("cant find any brave cookies file")
+    bail!("Can't find any Brave cookies file")
 }
 
 
@@ -126,7 +126,7 @@ pub fn find_safari_based_paths(browser_config: &BrowserConfig) -> Result<PathBuf
             }
         }
     }
-    bail!("cant find any brave cookies file")
+    bail!("Can't find any Brave cookies file")
 }
 
 #[cfg(target_os = "windows")]
@@ -150,5 +150,5 @@ pub fn find_ie_based_paths(browser_config: &BrowserConfig) -> Result<PathBuf> {
     }
     
 
-    bail!("cant find any IE cookies file")
+    bail!("Can't find any IE cookies file")
 }

--- a/rookie-rs/src/common/secrets.rs
+++ b/rookie-rs/src/common/secrets.rs
@@ -74,7 +74,7 @@ cfg_if::cfg_if! {
         
             let m = libsecret_call(&connection, "Unlock", vec![path])?;
             let reply: (Vec<ObjectPath>, ObjectPath)  = m.body()?;
-            let object_path = reply.0.first().ok_or(anyhow!("Cant unlock"))?;
+            let object_path = reply.0.first().ok_or(anyhow!("Can't unlock"))?;
         
         
             let mut content = HashMap::<&str, &str>::new();
@@ -88,7 +88,7 @@ cfg_if::cfg_if! {
             let m = libsecret_call(&connection, "GetSecrets", &(vec![object_path], session))?;
             type Response<'a> = (ObjectPath<'a>, Vec<u8>, Vec<u8>, String);
             let reply: HashMap::<ObjectPath, Response>  = m.body()?;
-            let inner = reply.get(object_path).ok_or(anyhow!("Cant get secrets"))?;
+            let inner = reply.get(object_path).ok_or(anyhow!("Can't get secrets"))?;
             let secret = &inner.2;
             
             Ok(String::from_utf8(secret.clone())?)

--- a/rookie-rs/src/config.rs
+++ b/rookie-rs/src/config.rs
@@ -159,7 +159,7 @@ cfg_if::cfg_if! {
         };
 
         
-        pub static LIBRE_WOLF_CONFIG: BrowserConfig<'static> = BrowserConfig {
+        pub static LIBREWOLF_CONFIG: BrowserConfig<'static> = BrowserConfig {
             data_paths: &[
                 "%LOCALAPPDATA%/librewolf",
                 "%APPDATA%/librewolf",
@@ -292,7 +292,7 @@ cfg_if::cfg_if! {
         };
 
          
-        pub static LIBRE_WOLF_CONFIG: BrowserConfig<'static> = BrowserConfig {
+        pub static LIBREWOLF_CONFIG: BrowserConfig<'static> = BrowserConfig {
             data_paths: &[
                 "~/snap/librewolf/common/.librewolf",
                 "~/.librewolf"
@@ -362,7 +362,7 @@ cfg_if::cfg_if! {
         };
         
         
-        pub static LIBRE_WOLF_CONFIG: BrowserConfig<'static> = BrowserConfig {
+        pub static LIBREWOLF_CONFIG: BrowserConfig<'static> = BrowserConfig {
             data_paths: &[
                 "~/Library/Application Support/librewolf"
             ],

--- a/rookie-rs/src/lib.rs
+++ b/rookie-rs/src/lib.rs
@@ -24,7 +24,7 @@ cfg_if::cfg_if! {
     }
 }
 
-/// Returns cookies from firefox
+/// Returns cookies from Firefox
 ///
 /// # Arguments
 ///
@@ -44,7 +44,7 @@ pub fn firefox(domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {
     firefox_based(db_path, domains)
 }
 
-/// Returns cookies from libre wolf
+/// Returns cookies from LibreWolf
 ///
 /// # Arguments
 ///
@@ -64,7 +64,7 @@ pub fn librewolf(domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {
     firefox_based(db_path, domains)
 }
 
-/// Returns cookies from chrome
+/// Returns cookies from Chrome
 ///
 /// # Arguments
 ///
@@ -91,7 +91,7 @@ pub fn chrome(domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {
     }
 }
 
-/// Returns cookies from chromium
+/// Returns cookies from Chromium
 ///
 /// # Arguments
 ///
@@ -118,7 +118,7 @@ pub fn chromium(domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {
     }
 }
 
-/// Returns cookies from brave
+/// Returns cookies from Brave
 ///
 /// # Arguments
 ///
@@ -145,7 +145,7 @@ pub fn brave(domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {
     }
 }
 
-/// Returns cookies from edge
+/// Returns cookies from Edge
 ///
 /// # Arguments
 ///
@@ -172,7 +172,7 @@ pub fn edge(domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {
     }
 }
 
-/// Returns cookies from vivaldi
+/// Returns cookies from Vivaldi
 ///
 /// # Arguments
 ///
@@ -199,7 +199,7 @@ pub fn vivaldi(domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {
     }
 }
 
-/// Returns cookies from opera
+/// Returns cookies from Opera
 ///
 /// # Arguments
 ///
@@ -226,7 +226,7 @@ pub fn opera(domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {
     }
 }
 
-/// Returns cookies from opera gx
+/// Returns cookies from Opera GX
 ///
 /// # Arguments
 ///
@@ -253,7 +253,7 @@ pub fn opera_gx(domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {
     }
 }
 
-/// Returns cookies from octo browser
+/// Returns cookies from Octo Browser
 ///
 /// # Arguments
 ///
@@ -265,7 +265,7 @@ pub fn opera_gx(domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {
 ///
 /// fn main() {
 ///     let domains = vec!["google.com"];
-///     let cookies = rookie::octo(Some(domains));
+///     let cookies = rookie::octo_browser(Some(domains));
 /// }
 /// ```
 #[cfg(target_os = "windows")]
@@ -274,7 +274,7 @@ pub fn octo_browser(domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {
     chromium_based(PathBuf::from(key), db_path, domains)
 }
 
-/// Returns cookies from safari (MacOS only)
+/// Returns cookies from Safari (macOS only)
 ///
 /// # Arguments
 ///
@@ -295,7 +295,7 @@ pub fn safari(domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {
     safari_based(db_path, domains)
 }
 
-/// Returns cookies from internet explorer (Windows only)
+/// Returns cookies from Internet Explorer (Windows only)
 ///
 /// # Arguments
 ///
@@ -334,7 +334,7 @@ pub fn internet_explorer(domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {
 pub fn load(domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {
     let mut cookies = Vec::new();
 
-    let mut browser_types = vec![firefox, libre_wolf, opera, edge, chromium, brave, vivaldi];
+    let mut browser_types = vec![firefox, librewolf, opera, edge, chromium, brave, vivaldi];
     cfg_if::cfg_if! {
         if #[cfg(target_os = "windows")] {
             browser_types.push(chrome);
@@ -436,5 +436,5 @@ pub fn any_browser(
             }
         }
     }
-    bail!("cant find any cookies");
+    bail!("Can't find any cookies");
 }

--- a/rookie-rs/src/lib.rs
+++ b/rookie-rs/src/lib.rs
@@ -56,11 +56,11 @@ pub fn firefox(domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {
 ///
 /// fn main() {
 ///     let domains = vec!["google.com"];
-///     let cookies = rookie::libre_wolf(Some(domains));
+///     let cookies = rookie::librewolf(Some(domains));
 /// }
 /// ```
-pub fn libre_wolf(domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {
-    let db_path = paths::find_mozilla_based_paths(&config::LIBRE_WOLF_CONFIG)?;
+pub fn librewolf(domains: Option<Vec<&str>>) -> Result<Vec<Cookie>> {
+    let db_path = paths::find_mozilla_based_paths(&config::LIBREWOLF_CONFIG)?;
     firefox_based(db_path, domains)
 }
 


### PR DESCRIPTION
Currently. LibreWolf is mentioned everywhere as `libre_wolf`. This is inconsistent, as Firefox is mentioned as `firefox`.

I also updated Cargo dependencies and improved some typography here and there.
Thank you for your project