### PR TITLE
Fix rust to netscape conversion

### DIFF
--- a/rookie-rs/src/common/format.rs
+++ b/rookie-rs/src/common/format.rs
@@ -12,11 +12,16 @@ pub fn netscape(cookies: Vec<Cookie>) -> String {
   ", crate::version()}
   .to_string();
   for cookie in cookies {
-    let subdomain = "TRUE";
-    let https_only = "FALSE";
+    let domain = if cookie.http_only {
+      format!("#HttpOnly_{}", cookie.domain)
+    } else {
+      cookie.domain
+    };
+    let subdomain = domain.starts_with(".").to_string().to_uppercase();
+    let https_only = cookie.secure.to_string().to_uppercase();
     data.push_str(&format!(
       "{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
-      cookie.domain,
+      domain,
       subdomain,
       cookie.path,
       https_only,

--- a/rookie-rs/src/common/format.rs
+++ b/rookie-rs/src/common/format.rs
@@ -17,7 +17,7 @@ pub fn netscape(cookies: Vec<Cookie>) -> String {
     } else {
       cookie.domain
     };
-    let subdomain = domain.starts_with(".").to_string().to_uppercase();
+    let subdomain = domain.starts_with('.').to_string().to_uppercase();
     let https_only = cookie.secure.to_string().to_uppercase();
     data.push_str(&format!(
       "{}\t{}\t{}\t{}\t{}\t{}\t{}\n",


### PR DESCRIPTION
See #41 for the equivalent in python.

- set https_only using the value of secure of the cookie
- set subdomain according to domain starting with .
- add prefix #HttpOnly_ to domain for http-only cookies

See, for instance, https://docs.cyotek.com/cyowcopy/current/netscapecookieformat.html for documentation of the netscape cookie format.