### PR TITLE
Fix cookie decrypting for Chrome 133+

### DIFF
--- a/rookie-rs/Cargo.toml
+++ b/rookie-rs/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/lib.rs"
 indoc = "2.0.5"
 aes = "0.8"
 aes-gcm = "0.10"
+chacha20poly1305 = "0.10"
 cbc = "0.1"
 eyre = { version = "0.6.12" }
 glob = "0.3"

--- a/rookie-rs/src/browser/chromium.rs
+++ b/rookie-rs/src/browser/chromium.rs
@@ -157,7 +157,7 @@ fn get_keys(config: &Browser) -> Result<Vec<Vec<u8>>> {
 fn decrypt_encrypted_value(
   value: String,
   encrypted_value: &[u8],
-  keys: Vec<Vec<u8>>,
+  keys: &[Vec<u8>],
 ) -> Result<String> {
   let key_type = &encrypted_value[..3];
   if !value.is_empty() || !(key_type == b"v11" || key_type == b"v10" || key_type == b"v20") {
@@ -336,7 +336,7 @@ fn query_cookies(
     if encrypted_value.is_empty() {
       continue;
     }
-    let decrypted_value = decrypt_encrypted_value(value, &encrypted_value, keys.to_owned())?;
+    let decrypted_value = decrypt_encrypted_value(value, &encrypted_value, &keys)?;
     let http_only: bool = row.get(7)?;
 
     let same_site: i64 = row.get(8)?;

--- a/rookie-rs/src/browser/chromium.rs
+++ b/rookie-rs/src/browser/chromium.rs
@@ -206,7 +206,7 @@ fn decrypt_encrypted_value(
 fn decrypt_encrypted_value(
   value: String,
   encrypted_value: &[u8],
-  keys: Vec<Vec<u8>>,
+  keys: &[Vec<u8>],
 ) -> Result<String> {
   // cbc
   if !value.is_empty() {

--- a/rookie-rs/src/windows/appbound/impersonate.rs
+++ b/rookie-rs/src/windows/appbound/impersonate.rs
@@ -114,11 +114,6 @@ fn get_process_handle(pid: u32) -> Result<HANDLE> {
   }
 }
 
-fn close_handle(handle: HANDLE) -> Result<()> {
-  unsafe { CloseHandle(handle)? };
-  Ok(())
-}
-
 fn get_system_token(lsass_handle: HANDLE) -> Result<HANDLE> {
   let mut token_handle = HANDLE::default();
   unsafe {
@@ -147,8 +142,8 @@ pub fn start_impersonate() -> Result<HANDLE> {
   let pid = get_system_process_pid()?;
   let lsass_handle = get_process_handle(pid)?;
   let duplicated_token = get_system_token(lsass_handle)?;
-  close_handle(lsass_handle)?;
   unsafe {
+    CloseHandle(lsass_handle)?;
     ImpersonateLoggedOnUser(duplicated_token)?;
   }
   Ok(duplicated_token)

--- a/rookie-rs/src/windows/appbound/mod.rs
+++ b/rookie-rs/src/windows/appbound/mod.rs
@@ -52,14 +52,14 @@ pub fn get_keys(key64: &str) -> Result<Vec<Vec<u8>>> {
     let aes_key = Key::<Aes256Gcm>::from_slice(aes_key);
     let cipher = Aes256Gcm::new(aes_key);
     if let Ok(plain) = cipher.decrypt(nonce, ciphertext) {
-      keys.push(plain)
+      keys.push(plain);
     }
   } else if flag == 2 {
     let chacha_key = b"\xE9\x8F\x37\xD7\xF4\xE1\xFA\x43\x3D\x19\x30\x4D\xC2\x25\x80\x42\x09\x0E\x2D\x1D\x7E\xEA\x76\x70\xD4\x1F\x73\x8D\x08\x72\x96\x60";
     let chacha_key = Key::<ChaCha20Poly1305>::from_slice(chacha_key);
     let cipher = ChaCha20Poly1305::new(chacha_key);
     if let Ok(plain) = cipher.decrypt(nonce, ciphertext) {
-      keys.push(plain)
+      keys.push(plain);
     }
   }
 

--- a/rookie-rs/src/windows/appbound/mod.rs
+++ b/rookie-rs/src/windows/appbound/mod.rs
@@ -25,6 +25,18 @@ fn decrypt_dpapi(key: &[u8], as_system: bool) -> Result<Vec<u8>> {
   Ok(result)
 }
 
+fn decrypt_ncrypt(key: &[u8], as_system: bool) -> Result<Vec<u8>> {
+  let mut handle = None;
+  if as_system {
+    handle = Some(impersonate::start_impersonate()?);
+  }
+  let result = crate::windows::ncrypt::decrypt(key)?;
+  if let Some(handle) = handle {
+    impersonate::stop_impersonate(handle)?;
+  }
+  Ok(result)
+}
+
 pub fn get_keys(key64: &str) -> Result<Vec<Vec<u8>>> {
   let mut keys: Vec<Vec<u8>> = Vec::new();
 
@@ -42,23 +54,41 @@ pub fn get_keys(key64: &str) -> Result<Vec<Vec<u8>>> {
   // Chrome also decrypt the decrypted key with hardcoded AES key from elevation_service.exe
   let decrypted_key = &key[key.len() - 61..];
   let flag = decrypted_key[0];
-  let iv = &decrypted_key[1..1 + 12];
-  let ciphertext = &decrypted_key[1 + 12..];
-  let nonce = GenericArray::from_slice(iv); // 96-bits; unique per message
   if flag == 1 {
+    let iv = &decrypted_key[1..1 + 12];
+    let ciphertext = &decrypted_key[1 + 12..];
+    let nonce = GenericArray::from_slice(iv);
+
     let aes_key = b"\xB3\x1C\x6E\x24\x1A\xC8\x46\x72\x8D\xA9\xC1\xFA\xC4\x93\x66\x51\xCF\xFB\x94\x4D\x14\x3A\xB8\x16\x27\x6B\xCC\x6D\xA0\x28\x47\x87";
-    let aes_key = Key::<Aes256Gcm>::from_slice(aes_key);
-    let cipher = Aes256Gcm::new(aes_key);
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(aes_key));
     if let Ok(plain) = cipher.decrypt(nonce, ciphertext) {
       keys.push(plain);
     }
   } else if flag == 2 {
+    let iv = &decrypted_key[1..1 + 12];
+    let ciphertext = &decrypted_key[1 + 12..];
+    let nonce = GenericArray::from_slice(iv);
+
     let chacha_key = b"\xE9\x8F\x37\xD7\xF4\xE1\xFA\x43\x3D\x19\x30\x4D\xC2\x25\x80\x42\x09\x0E\x2D\x1D\x7E\xEA\x76\x70\xD4\x1F\x73\x8D\x08\x72\x96\x60";
-    let chacha_key = Key::<ChaCha20Poly1305>::from_slice(chacha_key);
-    let cipher = ChaCha20Poly1305::new(chacha_key);
+    let cipher = ChaCha20Poly1305::new(Key::<ChaCha20Poly1305>::from_slice(chacha_key));
     if let Ok(plain) = cipher.decrypt(nonce, ciphertext) {
       keys.push(plain);
     }
+  } else if flag == 3 {
+    let encrypted_aes_key = &decrypted_key[1..1 + 32];
+    let iv = &decrypted_key[1 + 32..1 + 32 + 12];
+    let ciphertext = &decrypted_key[1 + 32 + 12..];
+    let nonce = GenericArray::from_slice(iv);
+
+    let xor_key = b"\xCC\xF8\xA1\xCE\xC5\x66\x05\xB8\x51\x75\x52\xBA\x1A\x2D\x06\x1C\x03\xA2\x9E\x90\x27\x4F\xB2\xFC\xF5\x9B\xA4\xB7\x5C\x39\x23\x90";
+    let mut aes_key = decrypt_ncrypt(encrypted_aes_key, true)?;
+    aes_key.iter_mut().zip(xor_key).for_each(|(a, b)| *a ^= b);
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&aes_key));
+    if let Ok(plain) = cipher.decrypt(nonce, ciphertext) {
+      keys.push(plain);
+    }
+  } else {
+    log::warn!("Unsupported flag: {}", flag);
   }
 
   Ok(keys)

--- a/rookie-rs/src/windows/appbound/mod.rs
+++ b/rookie-rs/src/windows/appbound/mod.rs
@@ -18,11 +18,11 @@ fn decrypt_dpapi(key: &[u8], as_system: bool) -> Result<Vec<u8>> {
   if as_system {
     handle = Some(impersonate::start_impersonate()?);
   }
-  let result = crate::windows::dpapi::decrypt(key)?;
+  let result = crate::windows::dpapi::decrypt(key);
   if let Some(handle) = handle {
     impersonate::stop_impersonate(handle)?;
   }
-  Ok(result)
+  result
 }
 
 fn decrypt_ncrypt(key: &[u8], as_system: bool) -> Result<Vec<u8>> {
@@ -30,11 +30,11 @@ fn decrypt_ncrypt(key: &[u8], as_system: bool) -> Result<Vec<u8>> {
   if as_system {
     handle = Some(impersonate::start_impersonate()?);
   }
-  let result = crate::windows::ncrypt::decrypt(key)?;
+  let result = crate::windows::ncrypt::decrypt(key);
   if let Some(handle) = handle {
     impersonate::stop_impersonate(handle)?;
   }
-  Ok(result)
+  result
 }
 
 pub fn get_keys(key64: &str) -> Result<Vec<Vec<u8>>> {

--- a/rookie-rs/src/windows/dpapi.rs
+++ b/rookie-rs/src/windows/dpapi.rs
@@ -3,7 +3,7 @@ use std::{ffi::c_void, ptr};
 use eyre::{anyhow, bail, Result};
 use windows::Win32::{Foundation, Security::Cryptography};
 
-pub fn decrypt(keydpapi: &mut [u8]) -> Result<Vec<u8>> {
+pub fn decrypt(keydpapi: &[u8]) -> Result<Vec<u8>> {
   // https://learn.microsoft.com/en-us/windows/win32/api/dpapi/nf-dpapi-cryptunprotectdata
   // https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-localfree
   // https://docs.rs/winapi/latest/winapi/um/dpapi/index.html
@@ -11,7 +11,7 @@ pub fn decrypt(keydpapi: &mut [u8]) -> Result<Vec<u8>> {
 
   let data_in = Cryptography::CRYPT_INTEGER_BLOB {
     cbData: keydpapi.len() as u32,
-    pbData: keydpapi.as_mut_ptr(),
+    pbData: keydpapi.as_ptr() as *mut u8, // Safety: CryptUnprotectData will not mutate the contents of data_in, a mutable pointer is required due to a typing quirk
   };
   let mut data_out = Cryptography::CRYPT_INTEGER_BLOB {
     cbData: 0,
@@ -19,7 +19,7 @@ pub fn decrypt(keydpapi: &mut [u8]) -> Result<Vec<u8>> {
   };
 
   unsafe {
-    let _ = match Cryptography::CryptUnprotectData(
+    let _ = Cryptography::CryptUnprotectData(
       &data_in,
       Some(ptr::null_mut()),
       Some(ptr::null_mut()),
@@ -27,10 +27,7 @@ pub fn decrypt(keydpapi: &mut [u8]) -> Result<Vec<u8>> {
       Some(ptr::null_mut()),
       0,
       &mut data_out,
-    ) {
-      Ok(_) => Ok(()),
-      Err(_) => Err(anyhow!("CryptUnprotectData failed")),
-    };
+    );
   }
   if data_out.pbData.is_null() {
     bail!("CryptUnprotectData returned a null pointer");

--- a/rookie-rs/src/windows/dpapi.rs
+++ b/rookie-rs/src/windows/dpapi.rs
@@ -1,6 +1,6 @@
 use std::{ffi::c_void, ptr};
 
-use eyre::{anyhow, bail, Result};
+use eyre::{bail, Context, Result};
 use windows::Win32::{Foundation, Security::Cryptography};
 
 pub fn decrypt(keydpapi: &[u8]) -> Result<Vec<u8>> {
@@ -19,7 +19,7 @@ pub fn decrypt(keydpapi: &[u8]) -> Result<Vec<u8>> {
   };
 
   unsafe {
-    let _ = Cryptography::CryptUnprotectData(
+    Cryptography::CryptUnprotectData(
       &data_in,
       Some(ptr::null_mut()),
       Some(ptr::null_mut()),
@@ -27,7 +27,8 @@ pub fn decrypt(keydpapi: &[u8]) -> Result<Vec<u8>> {
       Some(ptr::null_mut()),
       0,
       &mut data_out,
-    );
+    )
+    .context("CryptUnprotectData failed")?;
   }
   if data_out.pbData.is_null() {
     bail!("CryptUnprotectData returned a null pointer");
@@ -37,10 +38,7 @@ pub fn decrypt(keydpapi: &[u8]) -> Result<Vec<u8>> {
     unsafe { std::slice::from_raw_parts(data_out.pbData, data_out.cbData as usize).to_vec() };
   let pbdata_hlocal = Foundation::HLOCAL(data_out.pbData as *mut c_void);
   unsafe {
-    let _ = match Foundation::LocalFree(pbdata_hlocal) {
-      Ok(_) => Ok(()),
-      Err(_) => Err(anyhow!("LocalFree failed")),
-    };
+    Foundation::LocalFree(pbdata_hlocal)?;
   };
   Ok(decrypted_data)
 }

--- a/rookie-rs/src/windows/dpapi.rs
+++ b/rookie-rs/src/windows/dpapi.rs
@@ -1,6 +1,6 @@
 use std::{ffi::c_void, ptr};
 
-use eyre::{anyhow, bail, Result};
+use eyre::{bail, Result};
 use windows::Win32::{Foundation, Security::Cryptography};
 
 pub fn decrypt(keydpapi: &[u8]) -> Result<Vec<u8>> {
@@ -37,10 +37,7 @@ pub fn decrypt(keydpapi: &[u8]) -> Result<Vec<u8>> {
     unsafe { std::slice::from_raw_parts(data_out.pbData, data_out.cbData as usize).to_vec() };
   let pbdata_hlocal = Foundation::HLOCAL(data_out.pbData as *mut c_void);
   unsafe {
-    let _ = match Foundation::LocalFree(pbdata_hlocal) {
-      Ok(_) => Ok(()),
-      Err(_) => Err(anyhow!("LocalFree failed")),
-    };
+    let _ = Foundation::LocalFree(pbdata_hlocal);
   };
   Ok(decrypted_data)
 }

--- a/rookie-rs/src/windows/mod.rs
+++ b/rookie-rs/src/windows/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "appbound")]
 pub(crate) mod appbound;
 pub(crate) mod dpapi;
+pub(crate) mod ncrypt;
 pub(crate) mod restart_manager;
 pub(crate) mod shadow_copy;

--- a/rookie-rs/src/windows/ncrypt.rs
+++ b/rookie-rs/src/windows/ncrypt.rs
@@ -1,0 +1,51 @@
+use eyre::{bail, Context, Result};
+use windows::{core::w, Win32::Security::Cryptography};
+
+pub fn decrypt(keydpapi: &[u8]) -> Result<Vec<u8>> {
+  let mut provider_handle = Cryptography::NCRYPT_PROV_HANDLE::default();
+  unsafe {
+    Cryptography::NCryptOpenStorageProvider(
+      &mut provider_handle,
+      w!("Microsoft Software Key Storage Provider"),
+      0,
+    )
+    .context("NCryptOpenStorageProvider failed")?;
+  }
+
+  let mut key_handle = Cryptography::NCRYPT_KEY_HANDLE::default();
+  unsafe {
+    Cryptography::NCryptOpenKey(
+      provider_handle,
+      &mut key_handle,
+      w!("Google Chromekey1"),
+      Cryptography::CERT_KEY_SPEC::default(),
+      Cryptography::NCRYPT_FLAGS::default(),
+    )
+    .context("NCryptOpenKey failed")?;
+  }
+
+  let mut output_buffer = vec![0u8; keydpapi.len()];
+  let mut output_length = 0u32;
+  unsafe {
+    Cryptography::NCryptDecrypt(
+      key_handle,
+      Some(keydpapi),
+      None,
+      Some(&mut output_buffer),
+      &mut output_length,
+      Cryptography::NCRYPT_SILENT_FLAG,
+    )
+    .context("NCryptDecrypt failed")?;
+  }
+  if output_length as usize > output_buffer.len() {
+    bail!("NCryptDecrypt output longer than input");
+  }
+  output_buffer.truncate(output_length as usize);
+
+  unsafe {
+    Cryptography::NCryptFreeObject(key_handle)?;
+    Cryptography::NCryptFreeObject(provider_handle)?;
+  }
+
+  Ok(output_buffer)
+}


### PR DESCRIPTION
Fixes https://github.com/thewh1teagle/rookie/issues/95. Based on https://github.com/runassu/chrome_v20_decryption. Big thanks to runassu and others for extracting the new decryption key and figuring out the new encryption algorithm.

Tested and working on Chrome 135.0.7049.115 on Windows 10.