### PR TITLE
allow user to support multiple profiles: make paths module public & add functions for getting all cookie paths

### DIFF
--- a/rookie-rs/src/common/mod.rs
+++ b/rookie-rs/src/common/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod date;
 pub mod enums;
 pub mod format;
-pub(crate) mod paths;
+pub mod paths;
 pub(crate) mod sqlite;
 pub(crate) mod utils;

--- a/rookie-rs/src/common/paths.rs
+++ b/rookie-rs/src/common/paths.rs
@@ -61,12 +61,15 @@ pub fn find_chrome_based_path(config: &Browser) -> Result<(PathBuf, PathBuf)> {
 pub fn find_mozilla_based_paths(config: &Browser) -> Result<Vec<PathBuf>> {
   let mut results = Vec::new();
   for path in &config.paths {
+    // base paths
     let channels = config.channels.clone().unwrap_or(vec!["".to_string()]);
     for channel in channels {
+      // channels
       let path = path.replace("{channel}", &channel);
       let firefox_path = expand_path(path.as_str())?;
       let glob_paths = expand_glob_paths(firefox_path)?;
       for path in glob_paths {
+        // expanded glob paths
         let profiles_path = path.join("profiles.ini");
         let default_profile =
           get_default_profile(profiles_path.as_path()).unwrap_or("".to_string());
@@ -125,12 +128,15 @@ pub fn find_safari_based_path(config: &Browser) -> Result<PathBuf> {
 pub fn find_ie_based_paths(config: &Browser) -> Result<Vec<PathBuf>> {
   let mut results = Vec::new();
   for path in &config.paths {
+    // base paths
     let channels = config.channels.clone().unwrap_or(vec!["".to_string()]);
     for channel in channels {
+      // channels
       let path = path.replace("{channel}", &channel);
       let expanded_path = expand_path(path.as_str())?;
       let glob_paths = expand_glob_paths(expanded_path)?;
       for path in glob_paths {
+        // expanded glob paths
         if path.exists() {
           log::debug!("Found IE path {}", path.display());
           results.push(path);
@@ -139,7 +145,7 @@ pub fn find_ie_based_paths(config: &Browser) -> Result<Vec<PathBuf>> {
     }
   }
   if results.is_empty() {
-    bail!("Can't find IE cookies file");
+    bail!("Can't find cookies file");
   }
   Ok(results)
 }

--- a/rookie-rs/src/common/paths.rs
+++ b/rookie-rs/src/common/paths.rs
@@ -54,8 +54,8 @@ pub fn find_chrome_based_paths(config: &Browser) -> Result<Vec<(PathBuf, PathBuf
 
 pub fn find_chrome_based_path(config: &Browser) -> Result<(PathBuf, PathBuf)> {
   let paths = find_chrome_based_paths(&config)?;
-  let (key_path, db_path) = &paths[0];
-  Ok((key_path.clone(), db_path.clone()))
+  // SAFETY: paths is guaranteed non-empty, unwrap() is safe.
+  Ok(paths.into_iter().next().unwrap())
 }
 
 pub fn find_mozilla_based_paths(config: &Browser) -> Result<Vec<PathBuf>> {
@@ -89,7 +89,8 @@ pub fn find_mozilla_based_paths(config: &Browser) -> Result<Vec<PathBuf>> {
 
 pub fn find_mozilla_based_path(config: &Browser) -> Result<PathBuf> {
   let paths = find_mozilla_based_paths(config)?;
-  Ok(paths[0].clone())
+  // SAFETY: paths is guaranteed non-empty, unwrap() is safe.
+  Ok(paths.into_iter().next().unwrap())
 }
 
 #[cfg(target_os = "macos")]
@@ -121,7 +122,8 @@ pub fn find_safari_based_paths(config: &Browser) -> Result<Vec<PathBuf>> {
 #[cfg(target_os = "macos")]
 pub fn find_safari_based_path(config: &Browser) -> Result<PathBuf> {
   let paths = find_safari_based_paths(config)?;
-  Ok(paths[0].clone())
+  // SAFETY: paths is guaranteed non-empty, unwrap() is safe.
+  Ok(paths.into_iter().next().unwrap())
 }
 
 #[cfg(target_os = "windows")]
@@ -152,7 +154,8 @@ pub fn find_ie_based_paths(config: &Browser) -> Result<Vec<PathBuf>> {
 #[cfg(target_os = "windows")]
 pub fn find_ie_based_path(config: &Browser) -> Result<PathBuf> {
   let paths = find_ie_based_paths(config)?;
-  Ok(paths[0].clone())
+  // SAFETY: paths is guaranteed non-empty, unwrap() is safe.
+  Ok(paths.into_iter().next().unwrap())
 }
 #[cfg(target_os = "windows")]
 pub fn expand_path(path: &str) -> Result<PathBuf> {

--- a/rookie-rs/src/common/paths.rs
+++ b/rookie-rs/src/common/paths.rs
@@ -1,5 +1,5 @@
 use crate::{browser::mozilla::get_default_profile, config::Browser};
-use eyre::{anyhow, bail, Context, Result};
+use eyre::{bail, Context, Result};
 use std::{env, path::PathBuf};
 
 fn expand_glob_paths(path: PathBuf) -> Result<Vec<PathBuf>> {
@@ -14,7 +14,8 @@ fn expand_glob_paths(path: PathBuf) -> Result<Vec<PathBuf>> {
   Ok(paths)
 }
 
-pub fn find_chrome_based_paths(config: &Browser) -> Result<(PathBuf, PathBuf)> {
+pub fn find_chrome_based_paths(config: &Browser) -> Result<Vec<(PathBuf, PathBuf)>> {
+  let mut results = Vec::new();
   for path in &config.paths {
     // base paths
     let channels = config.channels.clone().unwrap_or(vec!["".to_string()]);
@@ -39,43 +40,58 @@ pub fn find_chrome_based_paths(config: &Browser) -> Result<(PathBuf, PathBuf)> {
               db_path.display(),
               key_path.display()
             );
-            return Ok((key_path, db_path));
+            results.push((key_path, db_path));
           }
         }
       }
     }
   }
-  Err(anyhow!("can't find cookies file"))
+  if results.is_empty() {
+    bail!("can't find cookies file");
+  }
+  Ok(results)
 }
 
-pub fn find_mozilla_based_paths(config: &Browser) -> Result<PathBuf> {
+pub fn find_chrome_based_path(config: &Browser) -> Result<(PathBuf, PathBuf)> {
+  let paths = find_chrome_based_paths(&config)?;
+  let (key_path, db_path) = &paths[0];
+  Ok((key_path.clone(), db_path.clone()))
+}
+
+pub fn find_mozilla_based_paths(config: &Browser) -> Result<Vec<PathBuf>> {
+  let mut results = Vec::new();
   for path in &config.paths {
-    // base paths
     let channels = config.channels.clone().unwrap_or(vec!["".to_string()]);
     for channel in channels {
-      // channels
       let path = path.replace("{channel}", &channel);
       let firefox_path = expand_path(path.as_str())?;
       let glob_paths = expand_glob_paths(firefox_path)?;
       for path in glob_paths {
-        // expanded glob paths
         let profiles_path = path.join("profiles.ini");
         let default_profile =
           get_default_profile(profiles_path.as_path()).unwrap_or("".to_string());
         let db_path = path.join(default_profile).join("cookies.sqlite");
         if db_path.exists() {
           log::debug!("Found mozilla path {}", db_path.display());
-          return Ok(db_path);
+          results.push(db_path);
         }
       }
     }
   }
+  if results.is_empty() {
+    bail!("Can't find cookies file");
+  }
+  Ok(results)
+}
 
-  bail!("Can't find cookies file")
+pub fn find_mozilla_based_path(config: &Browser) -> Result<PathBuf> {
+  let paths = find_mozilla_based_paths(config)?;
+  Ok(paths[0].clone())
 }
 
 #[cfg(target_os = "macos")]
-pub fn find_safari_based_paths(config: &Browser) -> Result<PathBuf> {
+pub fn find_safari_based_paths(config: &Browser) -> Result<Vec<PathBuf>> {
+  let mut results = Vec::new();
   for path in &config.paths {
     // base paths
     let channels = config.channels.clone().unwrap_or(vec!["".to_string()]);
@@ -88,36 +104,49 @@ pub fn find_safari_based_paths(config: &Browser) -> Result<PathBuf> {
         // expanded glob paths
         if path.exists() {
           log::debug!("Found safari path {}", path.display());
-          return Ok(path);
+          results.push(path);
         }
       }
     }
   }
-  bail!("Can't find cookies file")
+  if results.is_empty() {
+    bail!("Can't find cookies file")
+  }
+  Ok(results)
+}
+
+#[cfg(target_os = "macos")]
+pub fn find_safari_based_path(config: &Browser) -> Result<PathBuf> {
+  let paths = find_safari_based_paths(config)?;
+  Ok(paths[0].clone())
 }
 
 #[cfg(target_os = "windows")]
-pub fn find_ie_based_paths(config: &Browser) -> Result<PathBuf> {
+pub fn find_ie_based_paths(config: &Browser) -> Result<Vec<PathBuf>> {
+  let mut results = Vec::new();
   for path in &config.paths {
-    // base paths
     let channels = config.channels.clone().unwrap_or(vec!["".to_string()]);
     for channel in channels {
-      // channels
-
       let path = path.replace("{channel}", &channel);
-      let path = expand_path(path.as_str())?;
-      let glob_paths = expand_glob_paths(path)?;
+      let expanded_path = expand_path(path.as_str())?;
+      let glob_paths = expand_glob_paths(expanded_path)?;
       for path in glob_paths {
-        // expanded glob paths
         if path.exists() {
           log::debug!("Found IE path {}", path.display());
-          return Ok(path);
+          results.push(path);
         }
       }
     }
   }
-
-  bail!("Can't find cookies file")
+  if results.is_empty() {
+    bail!("Can't find IE cookies file");
+  }
+  Ok(results)
+}
+#[cfg(target_os = "windows")]
+pub fn find_ie_based_path(config: &Browser) -> Result<PathBuf> {
+  let paths = find_ie_based_paths(config)?;
+  Ok(paths[0].clone())
 }
 #[cfg(target_os = "windows")]
 pub fn expand_path(path: &str) -> Result<PathBuf> {

--- a/rookie-rs/src/lib.rs
+++ b/rookie-rs/src/lib.rs
@@ -56,7 +56,7 @@ pub fn version() -> String {
 /// ```
 pub fn firefox(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
   let config = get_browser_config("firefox");
-  let db_path = paths::find_mozilla_based_paths(config)?;
+  let db_path = paths::find_mozilla_based_path(config)?;
   firefox_based(db_path, domains)
 }
 
@@ -74,7 +74,7 @@ pub fn firefox(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
 /// ```
 pub fn librewolf(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
   let config = get_browser_config("librewolf");
-  let db_path = paths::find_mozilla_based_paths(config)?;
+  let db_path = paths::find_mozilla_based_path(config)?;
   firefox_based(db_path, domains)
 }
 
@@ -93,7 +93,7 @@ pub fn librewolf(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
 #[cfg(target_os = "linux")]
 pub fn cachy(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
   let config = get_browser_config("cachy");
-  let db_path = paths::find_mozilla_based_paths(config)?;
+  let db_path = paths::find_mozilla_based_path(config)?;
   firefox_based(db_path, domains)
 }
 
@@ -113,12 +113,12 @@ pub fn chrome(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
   let config = get_browser_config("chrome");
   #[cfg(target_os = "windows")]
   {
-    let (key, db_path) = paths::find_chrome_based_paths(config)?;
+    let (key, db_path) = paths::find_chrome_based_path(config)?;
     chromium_based(key, db_path, domains)
   }
   #[cfg(unix)]
   {
-    let (_, db_path) = paths::find_chrome_based_paths(config)?;
+    let (_, db_path) = paths::find_chrome_based_path(config)?;
     chromium_based(config, db_path, domains)
   }
 }
@@ -139,12 +139,12 @@ pub fn chromium(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
   let config = get_browser_config("chromium");
   #[cfg(target_os = "windows")]
   {
-    let (key, db_path) = paths::find_chrome_based_paths(config)?;
+    let (key, db_path) = paths::find_chrome_based_path(config)?;
     chromium_based(key, db_path, domains)
   }
   #[cfg(unix)]
   {
-    let (_, db_path) = paths::find_chrome_based_paths(config)?;
+    let (_, db_path) = paths::find_chrome_based_path(config)?;
     chromium_based(config, db_path, domains)
   }
 }
@@ -165,12 +165,12 @@ pub fn brave(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
   let config = get_browser_config("brave");
   #[cfg(target_os = "windows")]
   {
-    let (key, db_path) = paths::find_chrome_based_paths(config)?;
+    let (key, db_path) = paths::find_chrome_based_path(config)?;
     chromium_based(key, db_path, domains)
   }
   #[cfg(unix)]
   {
-    let (_, db_path) = paths::find_chrome_based_paths(config)?;
+    let (_, db_path) = paths::find_chrome_based_path(config)?;
     chromium_based(config, db_path, domains)
   }
 }
@@ -191,12 +191,12 @@ pub fn arc(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
   let config = get_browser_config("arc");
   #[cfg(target_os = "windows")]
   {
-    let (key, db_path) = paths::find_chrome_based_paths(config)?;
+    let (key, db_path) = paths::find_chrome_based_path(config)?;
     chromium_based(key, db_path, domains)
   }
   #[cfg(unix)]
   {
-    let (_, db_path) = paths::find_chrome_based_paths(config)?;
+    let (_, db_path) = paths::find_chrome_based_path(config)?;
     chromium_based(config, db_path, domains)
   }
 }
@@ -215,7 +215,7 @@ pub fn arc(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
 /// ```
 pub fn zen(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
   let config = get_browser_config("zen");
-  let db_path = paths::find_mozilla_based_paths(config)?;
+  let db_path = paths::find_mozilla_based_path(config)?;
   firefox_based(db_path, domains)
 }
 
@@ -235,12 +235,12 @@ pub fn edge(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
   let config = get_browser_config("edge");
   #[cfg(target_os = "windows")]
   {
-    let (key, db_path) = paths::find_chrome_based_paths(config)?;
+    let (key, db_path) = paths::find_chrome_based_path(config)?;
     chromium_based(key, db_path, domains)
   }
   #[cfg(unix)]
   {
-    let (_, db_path) = paths::find_chrome_based_paths(config)?;
+    let (_, db_path) = paths::find_chrome_based_path(config)?;
     chromium_based(config, db_path, domains)
   }
 }
@@ -261,12 +261,12 @@ pub fn vivaldi(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
   let config = get_browser_config("vivaldi");
   #[cfg(target_os = "windows")]
   {
-    let (key, db_path) = paths::find_chrome_based_paths(config)?;
+    let (key, db_path) = paths::find_chrome_based_path(config)?;
     chromium_based(key, db_path, domains)
   }
   #[cfg(unix)]
   {
-    let (_, db_path) = paths::find_chrome_based_paths(config)?;
+    let (_, db_path) = paths::find_chrome_based_path(config)?;
     chromium_based(config, db_path, domains)
   }
 }
@@ -287,12 +287,12 @@ pub fn opera(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
   let config = get_browser_config("opera");
   #[cfg(target_os = "windows")]
   {
-    let (key, db_path) = paths::find_chrome_based_paths(config)?;
+    let (key, db_path) = paths::find_chrome_based_path(config)?;
     chromium_based(key, db_path, domains)
   }
   #[cfg(unix)]
   {
-    let (_, db_path) = paths::find_chrome_based_paths(config)?;
+    let (_, db_path) = paths::find_chrome_based_path(config)?;
     chromium_based(config, db_path, domains)
   }
 }
@@ -313,12 +313,12 @@ pub fn opera_gx(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
   let config = get_browser_config("opera_gx");
   #[cfg(target_os = "windows")]
   {
-    let (key, db_path) = paths::find_chrome_based_paths(config)?;
+    let (key, db_path) = paths::find_chrome_based_path(config)?;
     chromium_based(key, db_path, domains)
   }
   #[cfg(unix)]
   {
-    let (_, db_path) = paths::find_chrome_based_paths(config)?;
+    let (_, db_path) = paths::find_chrome_based_path(config)?;
     chromium_based(config, db_path, domains)
   }
 }
@@ -338,7 +338,7 @@ pub fn opera_gx(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
 #[cfg(target_os = "windows")]
 pub fn octo_browser(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
   let config = get_browser_config("octo_browser");
-  let (key, db_path) = paths::find_chrome_based_paths(config)?;
+  let (key, db_path) = paths::find_chrome_based_path(config)?;
   chromium_based(key, db_path, domains)
 }
 
@@ -357,7 +357,7 @@ pub fn octo_browser(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
 #[cfg(target_os = "macos")]
 pub fn safari(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
   let config = get_browser_config("safari");
-  let db_path = paths::find_safari_based_paths(config)?;
+  let db_path = paths::find_safari_based_path(config)?;
   safari_based(db_path, domains)
 }
 
@@ -376,7 +376,7 @@ pub fn safari(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
 #[cfg(target_os = "windows")]
 pub fn internet_explorer(domains: Option<Vec<String>>) -> Result<Vec<Cookie>> {
   let config = get_browser_config("ie");
-  let db_path = paths::find_ie_based_paths(config)?;
+  let db_path = paths::find_ie_based_path(config)?;
   internet_explorer_based(db_path, domains)
 }
 


### PR DESCRIPTION
This purpose of this PR is to allow a rookie user to support multiple profiles.

### Overview
Lets say a rookie user wants to support multiple profiles in their code.
They can simply call **paths::find_{browser}_based_paths**, and let the user choose one of the paths. Then they can call **rookie::{browser}_based** with the chosen path.

### Changes
- Make the **common::paths** module public.
- Changes the behaviour of the **find_{browser}_based_paths** functions to return a vector of all paths found.
- Adds a new function **find_{browser}_based_path** which returns the first path from the result of **find_{browser}_based_paths**.
- Replaces all the uses of **find_{browser}_based_paths** with **find_{browser}_based_path**.

### Example:
Here is a chrome example, I have left out the code where a profile is actually chosen. You can imagine that bit.
```rust
let config = config::get_browser_config("chrome");
let paths = paths::find_chrome_based_paths(config)?;
// show paths to the user and let them pick one.
// lets say they chose the first one.
let choice = 0;
let (key, db_path) = paths[choice];
let cookies = rookie::chromium_based(key, db_path, None)
```