### PR TITLE
Add support for aarch64-pc-windows-msvc

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -36,6 +36,9 @@ jobs:
           - host: macos-latest
             target: aarch64-apple-darwin
             build: yarn build --target aarch64-apple-darwin
+          - host: windows-11-arm
+            build: yarn build --target aarch64-pc-windows-msvc
+            target: aarch64-pc-windows-msvc
     name: stable - ${{ matrix.settings.target }} - node@20
     runs-on: ${{ matrix.settings.host }}
     steps:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -124,6 +124,8 @@ jobs:
             target: aarch64-apple-darwin
           - host: windows-latest
             target: x86_64-pc-windows-msvc
+          - host: windows-11-arm
+            target: aarch64-pc-windows-msvc
         node:
           - "18"
           - "20"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -91,8 +91,8 @@ jobs:
 
       - name: Prepare appbound binaries
         run: |
-          C:\msys64\usr\bin\wget.exe https://github.com/thewh1teagle/rookie/releases/download/appbound-binaries/paexec.exe -O ..\..\rookie-rs\paexec.bin
-          C:\msys64\usr\bin\wget.exe https://github.com/thewh1teagle/rookie/releases/download/appbound-binaries/unprotect.exe -O ..\..\rookie-rs\unprotect.bin
+          curl https://github.com/thewh1teagle/rookie/releases/download/appbound-binaries/paexec.exe -o ..\..\rookie-rs\paexec.bin
+          curl https://github.com/thewh1teagle/rookie/releases/download/appbound-binaries/unprotect.exe -o ..\..\rookie-rs\unprotect.bin
         if: contains(matrix.settings.target, 'windows')
 
       - name: Build in docker

--- a/rookie-rs/build.rs
+++ b/rookie-rs/build.rs
@@ -7,5 +7,5 @@ fn commit_hash() -> String {
 }
 fn main() {
   let hash = commit_hash();
-  println!("cargo:rustc-env=COMMIT_HASH={hash}");
+  println!("cargo:rustc-env=COMMIT_HASH={}", hash);
 }

--- a/rookie-rs/build.rs
+++ b/rookie-rs/build.rs
@@ -7,5 +7,5 @@ fn commit_hash() -> String {
 }
 fn main() {
   let hash = commit_hash();
-  println!("cargo:rustc-env=COMMIT_HASH={}", hash);
+  println!("cargo:rustc-env=COMMIT_HASH={hash}");
 }


### PR DESCRIPTION
Add support for building windows 11 arm64 npm binaries.

wget.exe was replaced with curl because msys64 is not available on Windows 11 Arm64.

Node 18 is not available for Windows 11 Arm64, I'm not sure what to do here in terms of testing, the package builds, but there isn't an easy way to skip Node18/Windows11 Arm64 in the test matrix.