### PR TITLE
fix #53: support Python 3.13+, replace eyre with anyhow

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -9,14 +9,11 @@ name = "rookiepy"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = "0.20.3"
-pyo3-log = "0.9.0"
+pyo3 = { version = "0.23", features = ["abi3-py37", "anyhow"] }
+pyo3-log = "0.12"
 
 [target.'cfg(windows)'.dependencies]
-rookie = { path = "../../rookie-rs", version = "0.5.6", features = [
-  "appbound",
-  "pyo3",
-] }
+rookie = { path = "../../rookie-rs", version = "0.5.6", features = ["appbound"] }
 
 [target.'cfg(unix)'.dependencies]
-rookie = { path = "../../rookie-rs", version = "0.5.6", features = ["pyo3"] }
+rookie = { path = "../../rookie-rs", version = "0.5.6" }

--- a/bindings/python/src/browsers.rs
+++ b/bindings/python/src/browsers.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (db_path, domains=None, key_path=None))]
 pub fn any_browser(
   py: Python<'_>,
   db_path: &str,
@@ -22,6 +23,7 @@ pub fn any_browser(
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (domains=None))]
 pub fn firefox(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::firefox(domains)?;
   to_dict(py, cookies)
@@ -32,6 +34,7 @@ pub fn firefox(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyO
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (domains=None))]
 pub fn zen(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::zen(domains)?;
   to_dict(py, cookies)
@@ -42,6 +45,7 @@ pub fn zen(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObjec
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (domains=None))]
 pub fn librewolf(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::librewolf(domains)?;
   to_dict(py, cookies)
@@ -52,6 +56,7 @@ pub fn librewolf(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<P
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (domains=None))]
 pub fn chrome(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::chrome(domains)?;
   to_dict(py, cookies)
@@ -62,6 +67,7 @@ pub fn chrome(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyOb
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (domains=None))]
 pub fn arc(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::arc(domains)?;
   to_dict(py, cookies)
@@ -72,6 +78,7 @@ pub fn arc(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObjec
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (domains=None))]
 pub fn brave(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::brave(domains)?;
   to_dict(py, cookies)
@@ -82,6 +89,7 @@ pub fn brave(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObj
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (domains=None))]
 pub fn edge(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::edge(domains)?;
   to_dict(py, cookies)
@@ -92,6 +100,7 @@ pub fn edge(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObje
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (domains=None))]
 pub fn opera(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::opera(domains)?;
   to_dict(py, cookies)
@@ -102,6 +111,7 @@ pub fn opera(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObj
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (domains=None))]
 pub fn opera_gx(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::opera_gx(domains)?;
   to_dict(py, cookies)
@@ -112,6 +122,7 @@ pub fn opera_gx(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<Py
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (domains=None))]
 pub fn chromium(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::chromium(domains)?;
   to_dict(py, cookies)
@@ -122,6 +133,7 @@ pub fn chromium(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<Py
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (domains=None))]
 pub fn vivaldi(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::vivaldi(domains)?;
   to_dict(py, cookies)
@@ -134,6 +146,7 @@ pub fn vivaldi(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyO
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (db_path, domains=None))]
 pub fn firefox_based(
   py: Python<'_>,
   db_path: String,
@@ -148,6 +161,7 @@ pub fn firefox_based(
 /// :param domains: Optional list of domains to load cookies from
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (domains=None))]
 pub fn load(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::load(domains)?;
   to_dict(py, cookies)
@@ -158,6 +172,7 @@ pub fn load(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObje
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (domains=None))]
 #[cfg(target_os = "windows")]
 pub fn octo_browser(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::octo_browser(domains)?;
@@ -169,6 +184,7 @@ pub fn octo_browser(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Ve
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (domains=None))]
 #[cfg(target_os = "windows")]
 pub fn internet_explorer(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::internet_explorer(domains)?;
@@ -181,6 +197,7 @@ pub fn internet_explorer(py: Python<'_>, domains: Option<Vec<String>>) -> PyResu
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (key_path, db_path, domains=None))]
 #[cfg(target_os = "windows")]
 pub fn chromium_based(
   py: Python<'_>,
@@ -197,6 +214,7 @@ pub fn chromium_based(
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (domains=None))]
 #[cfg(target_os = "macos")]
 pub fn safari(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::safari(domains)?;
@@ -209,6 +227,7 @@ pub fn safari(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyOb
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
+#[pyo3(signature = (db_path, domains=None))]
 #[cfg(unix)]
 pub fn chromium_based(
   py: Python<'_>,

--- a/bindings/python/src/browsers.rs
+++ b/bindings/python/src/browsers.rs
@@ -8,15 +8,13 @@ use std::path::PathBuf;
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
 pub fn any_browser(
-  py: Python,
+  py: Python<'_>,
   db_path: &str,
   domains: Option<Vec<String>>,
   key_path: Option<&str>,
 ) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::any_browser(db_path, domains, key_path)?;
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }
 
 /// Extract Cookies from Firefox
@@ -24,11 +22,9 @@ pub fn any_browser(
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
-pub fn firefox(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
+pub fn firefox(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::firefox(domains)?;
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }
 
 /// Extract Cookies from Zen
@@ -36,11 +32,9 @@ pub fn firefox(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObjec
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
-pub fn zen(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
+pub fn zen(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::zen(domains)?;
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }
 
 /// Extract Cookies from LibreWolf browser
@@ -48,11 +42,9 @@ pub fn zen(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> 
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
-pub fn librewolf(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
+pub fn librewolf(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::librewolf(domains)?;
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }
 
 /// Extract Cookies from Google Chrome browser
@@ -60,11 +52,9 @@ pub fn librewolf(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObj
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
-pub fn chrome(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
+pub fn chrome(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::chrome(domains)?;
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }
 
 /// Extract Cookies from Arc browser
@@ -72,11 +62,9 @@ pub fn chrome(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
-pub fn arc(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
+pub fn arc(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::arc(domains)?;
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }
 
 /// Extract Cookies from Brave browser
@@ -84,12 +72,9 @@ pub fn arc(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> 
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
-pub fn brave(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
+pub fn brave(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::brave(domains)?;
-
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }
 
 /// Extract Cookies from Microsoft Edge browser
@@ -97,11 +82,9 @@ pub fn brave(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
-pub fn edge(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
+pub fn edge(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::edge(domains)?;
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }
 
 /// Extract Cookies from Opera browser
@@ -109,12 +92,9 @@ pub fn edge(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>>
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
-pub fn opera(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
+pub fn opera(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::opera(domains)?;
-
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }
 
 /// Extract Cookies from Opera GX browser
@@ -122,12 +102,9 @@ pub fn opera(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
-pub fn opera_gx(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
+pub fn opera_gx(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::opera_gx(domains)?;
-
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }
 
 /// Extract Cookies from Chromium browser
@@ -135,11 +112,9 @@ pub fn opera_gx(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObje
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
-pub fn chromium(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
+pub fn chromium(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::chromium(domains)?;
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }
 
 /// Extract Cookies from Vivaldi browser
@@ -147,12 +122,9 @@ pub fn chromium(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObje
 /// :param domains: Optional list of domains to extract only from them
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
-pub fn vivaldi(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
+pub fn vivaldi(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::vivaldi(domains)?;
-
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }
 
 /// Extract Cookies from Firefox-based browsers
@@ -163,14 +135,12 @@ pub fn vivaldi(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObjec
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
 pub fn firefox_based(
-  py: Python,
+  py: Python<'_>,
   db_path: String,
   domains: Option<Vec<String>>,
 ) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::firefox_based(PathBuf::from(db_path), domains)?;
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }
 
 /// Load Cookies from a browser
@@ -178,11 +148,9 @@ pub fn firefox_based(
 /// :param domains: Optional list of domains to load cookies from
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
-pub fn load(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
+pub fn load(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::load(domains)?;
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }
 
 /// Extract Cookies from Octo browser
@@ -191,12 +159,9 @@ pub fn load(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>>
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
 #[cfg(target_os = "windows")]
-pub fn octo_browser(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
+pub fn octo_browser(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::octo_browser(domains)?;
-
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }
 
 /// Extract Cookies from Internet Explorer
@@ -205,11 +170,9 @@ pub fn octo_browser(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<Py
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
 #[cfg(target_os = "windows")]
-pub fn internet_explorer(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
+pub fn internet_explorer(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::internet_explorer(domains)?;
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }
 
 /// Extract Cookies from Chromium-based browsers
@@ -220,15 +183,13 @@ pub fn internet_explorer(py: Python, domains: Option<Vec<String>>) -> PyResult<V
 #[pyfunction]
 #[cfg(target_os = "windows")]
 pub fn chromium_based(
-  py: Python,
+  py: Python<'_>,
   key_path: String,
   db_path: String,
   domains: Option<Vec<String>>,
 ) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::chromium_based(PathBuf::from(key_path), PathBuf::from(db_path), domains)?;
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }
 
 /// Extract Cookies from Safari browser
@@ -237,11 +198,9 @@ pub fn chromium_based(
 /// :return: A list of dictionaries of cookies
 #[pyfunction]
 #[cfg(target_os = "macos")]
-pub fn safari(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
+pub fn safari(py: Python<'_>, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject>> {
   let cookies = rookie::safari(domains)?;
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }
 
 /// Extract Cookies from Chromium-based browsers
@@ -252,7 +211,7 @@ pub fn safari(py: Python, domains: Option<Vec<String>>) -> PyResult<Vec<PyObject
 #[pyfunction]
 #[cfg(unix)]
 pub fn chromium_based(
-  py: Python,
+  py: Python<'_>,
   db_path: String,
   domains: Option<Vec<String>>,
 ) -> PyResult<Vec<PyObject>> {
@@ -267,7 +226,5 @@ pub fn chromium_based(
     osx_key_user: None,
   };
   let cookies = rookie::chromium_based(&config, PathBuf::from(db_path), domains)?;
-  let cookies = to_dict(py, cookies)?;
-
-  Ok(cookies)
+  to_dict(py, cookies)
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -9,7 +9,7 @@ fn version() -> PyResult<String> {
 }
 
 #[pymodule]
-fn rookiepy(_py: Python, m: &PyModule) -> PyResult<()> {
+fn rookiepy(m: &Bound<'_, PyModule>) -> PyResult<()> {
   pyo3_log::init();
   m.add_function(wrap_pyfunction!(firefox, m)?)?;
   m.add_function(wrap_pyfunction!(zen, m)?)?;
@@ -43,7 +43,7 @@ fn rookiepy(_py: Python, m: &PyModule) -> PyResult<()> {
   Ok(())
 }
 
-fn to_dict(py: Python, cookies: Vec<Cookie>) -> PyResult<Vec<PyObject>> {
+pub(crate) fn to_dict(py: Python<'_>, cookies: Vec<Cookie>) -> PyResult<Vec<PyObject>> {
   let mut cookie_objects: Vec<PyObject> = vec![];
   for cookie in cookies {
     let dict = PyDict::new(py);
@@ -56,7 +56,7 @@ fn to_dict(py: Python, cookies: Vec<Cookie>) -> PyResult<Vec<PyObject>> {
     dict.set_item("name", cookie.name)?;
     dict.set_item("value", cookie.value)?;
 
-    cookie_objects.push(dict.to_object(py));
+    cookie_objects.push(dict.into());
   }
   Ok(cookie_objects)
 }

--- a/rookie-rs/Cargo.toml
+++ b/rookie-rs/Cargo.toml
@@ -20,7 +20,7 @@ indoc = "2.0.5"
 aes = "0.8"
 aes-gcm = "0.10"
 cbc = "0.1"
-eyre = { version = "0.6.12" }
+anyhow = "1"
 glob = "0.3"
 log = "0.4"
 lz4_flex = "0.11"
@@ -38,7 +38,6 @@ tracing-subscriber = "0.3.18"
 
 [features]
 default = ["appbound"]
-pyo3 = ["eyre/pyo3"]
 appbound = []
 
 [target.'cfg(unix)'.dependencies]

--- a/rookie-rs/src/browser/chromium.rs
+++ b/rookie-rs/src/browser/chromium.rs
@@ -1,5 +1,5 @@
 use crate::common::{date, enums::*, sqlite};
-use eyre::{bail, Result};
+use anyhow::{bail, Result};
 use std::path::PathBuf;
 
 #[allow(unused)]
@@ -10,7 +10,7 @@ use crate::windows;
 
 #[cfg(not(target_os = "linux"))]
 #[allow(unused)]
-use eyre::ContextCompat;
+use anyhow::Context;
 
 #[cfg(target_os = "macos")]
 use crate::macos;
@@ -22,8 +22,6 @@ use aes_gcm::{
 };
 #[cfg(target_os = "windows")]
 use base64::{engine::general_purpose, Engine as _};
-#[cfg(target_os = "windows")]
-use eyre::Context;
 
 /// Returns cookies from chromium based browser
 #[cfg(target_os = "windows")]

--- a/rookie-rs/src/browser/internet_explorer.rs
+++ b/rookie-rs/src/browser/internet_explorer.rs
@@ -1,5 +1,5 @@
 use crate::common::{date, enums::Cookie};
-use eyre::Result;
+use anyhow::Result;
 use libesedb::EseDb;
 use std::path::PathBuf;
 

--- a/rookie-rs/src/browser/mozilla.rs
+++ b/rookie-rs/src/browser/mozilla.rs
@@ -1,5 +1,5 @@
 use crate::common::{date, enums::*, sqlite, utils};
-use eyre::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Result};
 use ini::Ini;
 use lz4_flex::block::decompress_size_prepended;
 use serde_json::Value;

--- a/rookie-rs/src/browser/safari.rs
+++ b/rookie-rs/src/browser/safari.rs
@@ -1,6 +1,6 @@
 use crate::common::{date, enums::*};
-use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use anyhow::{anyhow, bail, Context, Result};
+use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use std::{fs::File, io::Read, path::PathBuf, vec::Vec};
 
 /// 1. open cookies file

--- a/rookie-rs/src/browser/safari.rs
+++ b/rookie-rs/src/browser/safari.rs
@@ -1,6 +1,6 @@
 use crate::common::{date, enums::*};
 use byteorder::{BigEndian, ByteOrder, LittleEndian};
-use eyre::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use std::{fs::File, io::Read, path::PathBuf, vec::Vec};
 
 /// 1. open cookies file

--- a/rookie-rs/src/common/paths.rs
+++ b/rookie-rs/src/common/paths.rs
@@ -1,5 +1,5 @@
 use crate::{browser::mozilla::get_default_profile, config::Browser};
-use eyre::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use std::{env, path::PathBuf};
 
 fn expand_glob_paths(path: PathBuf) -> Result<Vec<PathBuf>> {

--- a/rookie-rs/src/common/sqlite.rs
+++ b/rookie-rs/src/common/sqlite.rs
@@ -1,4 +1,4 @@
-use eyre::{anyhow, Result};
+use anyhow::{anyhow, Result};
 use rusqlite::{Connection, OpenFlags};
 use std::path::PathBuf;
 use url::Url;

--- a/rookie-rs/src/lib.rs
+++ b/rookie-rs/src/lib.rs
@@ -15,11 +15,11 @@ pub use browser::{chromium::chromium_based, mozilla::firefox_based};
 
 // Private
 mod browser;
+use anyhow::bail;
+pub use anyhow::{self, Result};
 use common::paths;
 use config::get_browser_config;
 use enums::Cookie;
-use anyhow::bail;
-pub use anyhow::{self, Result};
 #[cfg(target_os = "linux")]
 mod linux;
 #[cfg(target_os = "windows")]

--- a/rookie-rs/src/lib.rs
+++ b/rookie-rs/src/lib.rs
@@ -18,8 +18,8 @@ mod browser;
 use common::paths;
 use config::get_browser_config;
 use enums::Cookie;
-use eyre::bail;
-pub use eyre::Result;
+use anyhow::bail;
+pub use anyhow::{self, Result};
 #[cfg(target_os = "linux")]
 mod linux;
 #[cfg(target_os = "windows")]

--- a/rookie-rs/src/linux/mod.rs
+++ b/rookie-rs/src/linux/mod.rs
@@ -1,4 +1,4 @@
-use eyre::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Result};
 use std::{collections::HashMap, sync::Arc};
 use zbus::{blocking::Connection, zvariant::ObjectPath, zvariant::Value, Message};
 

--- a/rookie-rs/src/macos/mod.rs
+++ b/rookie-rs/src/macos/mod.rs
@@ -1,4 +1,4 @@
-use eyre::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Result};
 
 use std::process::Command;
 pub fn get_osx_keychain_password(osx_key_service: &str, osx_key_user: &str) -> Result<String> {

--- a/rookie-rs/src/utils.rs
+++ b/rookie-rs/src/utils.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::path::PathBuf;
 
-use eyre::Result;
+use anyhow::Result;
 use rand::distributions::Alphanumeric;
 use rand::Rng;
 

--- a/rookie-rs/src/windows/appbound/impersonate.rs
+++ b/rookie-rs/src/windows/appbound/impersonate.rs
@@ -1,6 +1,6 @@
 use std::{ffi::OsString, os::windows::ffi::OsStringExt, path::Path};
 
-use eyre::{bail, Result};
+use anyhow::{bail, Result};
 use windows::Win32::System::Threading::OpenProcessToken;
 use windows::Win32::{
   Foundation::{CloseHandle, BOOL, HANDLE, NTSTATUS},

--- a/rookie-rs/src/windows/appbound/mod.rs
+++ b/rookie-rs/src/windows/appbound/mod.rs
@@ -2,8 +2,8 @@
 See https://github.com/runassu/chrome_v20_decryption/blob/main/decrypt_chrome_v20_cookie.py
 cargo build --release --features appbound
 */
-use base64::{prelude::BASE64_STANDARD, Engine};
 use anyhow::{anyhow, bail, Result};
+use base64::{prelude::BASE64_STANDARD, Engine};
 
 use aes_gcm::{
   aead::{generic_array::GenericArray, Aead, KeyInit},

--- a/rookie-rs/src/windows/appbound/mod.rs
+++ b/rookie-rs/src/windows/appbound/mod.rs
@@ -3,7 +3,7 @@ See https://github.com/runassu/chrome_v20_decryption/blob/main/decrypt_chrome_v2
 cargo build --release --features appbound
 */
 use base64::{prelude::BASE64_STANDARD, Engine};
-use eyre::{bail, eyre, Result};
+use anyhow::{anyhow, bail, Result};
 
 use aes_gcm::{
   aead::{generic_array::GenericArray, Aead, KeyInit},
@@ -52,7 +52,7 @@ pub fn get_keys(key64: &str) -> Result<Vec<Vec<u8>>> {
   let nonce = GenericArray::from_slice(iv); // 96-bits; unique per message
   if let Ok(plain) = cipher
     .decrypt(nonce, ciphertext.as_slice())
-    .map_err(|e| eyre!("{:?}", e))
+    .map_err(|e| anyhow!("{:?}", e))
   {
     keys.push(plain)
   }

--- a/rookie-rs/src/windows/dpapi.rs
+++ b/rookie-rs/src/windows/dpapi.rs
@@ -1,6 +1,6 @@
 use std::{ffi::c_void, ptr};
 
-use eyre::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Result};
 use windows::Win32::{Foundation, Security::Cryptography};
 
 pub fn decrypt(keydpapi: &mut [u8]) -> Result<Vec<u8>> {

--- a/rookie-rs/src/windows/shadow_copy.rs
+++ b/rookie-rs/src/windows/shadow_copy.rs
@@ -1,4 +1,4 @@
-use eyre::{bail, Context, Result};
+use anyhow::{bail, Context, Result};
 use privilege::user::privileged;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
@@ -33,7 +33,7 @@ pub fn shadow_copy(src: PathBuf, dst: PathBuf) -> Result<()> {
     dst.display()
   );
   rawcopy_rs_next::rawcopy(src.clone().to_str().unwrap(), dst.to_str().unwrap())
-    .map_err(|err| eyre::eyre!(Box::new(err)))
+    .map_err(|err| anyhow::anyhow!(Box::new(err)))
     .context(format!(
       "Can't shadow copy from {} to {}",
       src.display(),


### PR DESCRIPTION
Bump pyo3 0.20.3 -> 0.23 with abi3-py37 so rookiepy builds a single forward-compatible wheel that works on Python 3.7 through 3.14+.

eyre 0.6's pyo3 feature is pinned to pyo3 ^0.20 with no newer release available, which blocked the bump. Swap eyre for anyhow throughout rookie-rs and enable pyo3's anyhow feature so anyhow::Error converts to PyErr automatically -- the bindings drop their manual map_err helper and use `?` directly.

Verified: cp37-abi3 wheel imports and runs on Python 3.13.13 and 3.14.5.